### PR TITLE
Rename getItems() on collection to all()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -68,7 +68,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate {
 	 *
 	 * @return array
 	 */
-	public function getItems()
+	public function all()
 	{
 		return $this->items;
 	}


### PR DESCRIPTION
This looks cooler I think? I dunno if there is a conflict with any of the parents though. I was thinking toJson() might look better as toJSON() since its commonly written in caps, I know it would break the standard though so I dunno. Didn't pull that one.

Cheers matey!
