### PR TITLE
Add toString for Expression

### DIFF
--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -30,4 +30,14 @@ class Expression {
 		return $this->value;
 	}
 
+	/**
+	 * Get the value of the expression.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return (string) $this->getValue();
+	}
+
 }


### PR DESCRIPTION
When creating through the relationship synax ->foo()->create() an Expression passed in the array was giving the following Exception: http://pastie.org/private/g8cvwvgjgfmjxjkv8ttlyg

Setting this toString has fixed it, and seems like a fairly logical thing for it to do anyway.
