### PR TITLE
Fix migrate:install command doesn't work.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Console/Migrations/DatabaseMigrationRepository.php
@@ -109,7 +109,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function createRepository()
 	{
-		$schema = $this->getConnection()->getSchema();
+		$schema = $this->getConnection()->getSchemaBuilder();
 
 		$schema->create($this->table, function($table)
 		{


### PR DESCRIPTION
`migrate:install` command doesn't work because of a undefined function call `getSchema()` in place of `getSchemaBuilder()`
