### PR TITLE
Fixed issue with incrementing where primary key was not 'id'

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -464,7 +464,7 @@ abstract class Model implements ArrayableInterface {
 		{
 			if ($this->incrementing)
 			{
-				$this->$key = $query->insertGetId($this->attributes);
+				$this->{$this->getKeyName()} = $query->insertGetId($this->attributes);
 			}
 			else
 			{


### PR DESCRIPTION
A fix  in the save method , when the model is incrementing it calls getKeyName and increments the primary key instead of just  $this->id
