### PR TITLE
Added $unfillable array in model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -85,6 +85,12 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	protected $fillable = array();
 
+    /**
+     * The attributes that are not mass assignable.
+     * @var array
+     */
+    protected $unfillable = array();
+
 	/**
 	 * Indicates if the model exists.
 	 *
@@ -642,6 +648,17 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		$this->fillable = $fillable;
 	}
 
+    /**
+     * Set the unfillable attributes for the model
+     *
+     * @param  array  $unfillable
+     * @return void
+     */
+    public function setUnfillable(array $unfillable)
+    {
+        $this->unfillable = $unfillable;
+    }
+
 	/**
 	 * Determine if the given attribute may be mass assigned.
 	 *
@@ -650,7 +667,11 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	public function isFillable($key)
 	{
-		return empty($this->fillable) or in_array($key, $this->fillable);
+        if (in_array($key, $this->fillable)) return true;
+        if (in_array($key, $this->unfillable)) return false;
+        if (empty($this->fillable)) return true;
+
+        return false;
 	}
 
 	/**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -217,6 +217,15 @@ class EloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('bar', $model->age);
 	}
 
+	public function testUnfillable()
+	{
+		$model = new EloquentModelStub;
+		$model->setUnfillable(array('password'));
+		$model->fill(array('name' => 'foo', 'age' => 'bar', 'password' => 'baz'));
+		$this->assertFalse(isset($model->password));
+		$this->assertEquals('foo', $model->name);
+		$this->assertEquals('bar', $model->age);
+	}
 
 	public function testHasOneCreatesProperRelation()
 	{


### PR DESCRIPTION
Allows specifying items that are 'unfillable' via mass assignment.  Handy when there are many attributes and only a couple that are not fillable.  Suggested by someone on #laravel.
