### PR TITLE
Add support for calculated attributes which aren't stored in the database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -749,7 +749,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		// If the key references an attribute, we can just go ahead and return the
 		// plain attribute value from the model. This allows every attribute to
 		// be dynamically accessed through the _get method without accessors.
-		if (array_key_exists($key, $this->attributes))
+		if (array_key_exists($key, $this->attributes) or $this->hasGetMutator($key))
 		{
 			return $this->getPlainAttribute($key);
 		}
@@ -781,7 +781,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	protected function getPlainAttribute($key)
 	{
-		$value = $this->attributes[$key];
+		$value = isset($this->attributes[$key]) ? $this->attributes[$key] : null;
 
 		if ($this->hasGetMutator($key))
 		{
@@ -818,7 +818,8 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		{
 			$method = 'set'.camel_case($key);
 
-			return $this->attributes[$key] = $this->$method($value);
+			$value = $this->$method($value);
+			return is_null($value) ? null : $this->attributes[$key] = $value;
 		}
 
 		$this->attributes[$key] = $value;

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -26,6 +26,18 @@ class EloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(json_encode(array('name' => 'taylor')), $attributes['list_items']);
 	}
 
+	public function testCalculatedAttributes()
+	{
+		$model = new EloquentModelStub;
+		$model->password = 'secret';
+		$attributes = $model->getAttributes();
+
+		// ensure password attribute was not set to null
+		$this->assertFalse(array_key_exists('password', $attributes));
+		$this->assertEquals('******', $model->password);
+		$this->assertEquals('5ebe2294ecd0e0f08eab7690d2a6ee69', $attributes['password_hash']);
+		$this->assertEquals('5ebe2294ecd0e0f08eab7690d2a6ee69', $model->password_hash);
+	}
 
 	public function testNewInstanceReturnsNewInstanceWithAttributesSet()
 	{
@@ -341,6 +353,14 @@ class EloquentModelStub extends Illuminate\Database\Eloquent\Model {
 	public function setListItems($value)
 	{
 		return json_encode($value);
+	}
+	public function getPassword()
+	{
+		return '******';
+	}
+	public function setPassword($value)
+	{
+		$this->attributes['password_hash'] = md5($value);
 	}
 	public function belongsToStub()
 	{


### PR DESCRIPTION
This is my suggested patch for #40. I've added support for mutator methods which don't store anything in their database column.

New setter behavior:

```
public function setPassword($value)
{
    $this->attributes['password_hash'] = md5($value);
}
```

Because this setter doesn't return anything, `$this->attributes` is not updated (and therefore it does not attempt to store `password` in the database). Previously, `$this->attributes` was always updated, even if the setter returned `null`. If the setter returns any value, `$this->attributes` is still updated as it used to (all existing tests unit tests pass).

New getter behavior:

```
public function getFullName()
{
    return $this->first_name.' '.$this->last_name;
}
```

This value can now be accessed using `$model->full_name` (previously, `$model->full_name` would return `null` because `full_name` was not a key on `$this->attributes`, even if a getter method was defined).
