### PR TITLE
ArraybleInterface typehint for collection elements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -29,10 +29,10 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Add an item to the collection.
 	 *
-	 * @param  mixed  $item
+	 * @param  ArrayableInterface  $item
 	 * @return void
 	 */
-	public function add($item)
+	public function add(ArrayableInterface $item)
 	{
 		$this->items[] = $item;
 	}


### PR DESCRIPTION
That is required in the `toArray()` method of the collection itself.
