### PR TITLE
Allow custom constraints for load()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -39,7 +39,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		if (count($this->items) > 0)
 		{
 			$args = array(
-				$relation => is_null($constraints) ? function() {} : $constraints;
+				$relation => is_null($constraints) ? function() {} : $constraints,
 			);
 			$query = $this->first()->newQuery()->with($args);
 


### PR DESCRIPTION
I'd rather have a fluent interface, the possibility to set constraints and only one eager load per call.

Alternatively, we can use the same somewhat verbose array syntax that `Model::with()` supports.
