### PR TITLE
Fix constraints when eager-loading deep relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -335,7 +335,12 @@ class Builder {
 			{
 				$progress[] = $segment;
 
-				$results[$last = implode('.', $progress)] = function() {};
+				$last = implode('.', $progress);
+
+				// Make sure we don't overwrite an earlier defined constraint
+				if (!isset($results[$last])) {
+					$results[$last] = function() {};
+				}
 			}
 
 			// The eager load could have had constrains specified on it. We'll put them


### PR DESCRIPTION
Fixed a bug where constraints could be omitted when eager loading nested/deep relationships.

Example:

``` php
Studio::with(array(
    'Directors' => function($query) {
        $query->orderBy('created_at', 'desc');
    },
    'Directors.Movies'))->find(1);

```

In the previous version, any constraints for `Directors` were replaced by an empty function when iterating through `Directors.Movies`.
This could only be circumvented by changing the order of the eager-loaded relationships.

This pull-requests fixes that by ensuring no previously defined constraints are overwritten.
