### PR TITLE
Applying getMutators to collection before output as array or json string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -71,9 +71,21 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function toArray()
 	{
-		return array_map(function($value)
+		return array_map(function($model)
 		{
-			return $value->toArray();
+			$data = $model->toArray();
+			
+			$attributes = $model->getAttributes();
+			
+			foreach($attributes as $key => $value)
+			{
+				if($model->hasGetMutator($key))
+				{
+					$data[$key] = $model->$key;
+				}
+			}
+
+			return $data;
 
 		}, $this->items);
 	}


### PR DESCRIPTION
When returning a Eloquent Collection, I noticed the getMutator is not applied to the resulting array and thought, it will make it better to apply getMutator method to the each result before the collection is fully converted to an array or json string.
