### PR TITLE
Fix DateTime Timestamps when inserting a new Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -473,7 +473,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 			}
 			else
 			{
-				$query->insert($this->attributes);				
+				$query->insert($this->attributes);
 			}
 		}
 
@@ -507,7 +507,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 
 	/**
 	 * Getter for the created_at timestamp.
-	 * 
+	 *
 	 * @return DateTime
 	 */
 	protected function getCreatedAt()
@@ -517,7 +517,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 
 	/**
 	 * Getter for the updated_at timestamp.
-	 * 
+	 *
 	 * @return DateTime
 	 */
 	protected function getUpdatedAt()
@@ -527,7 +527,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 
 	/**
 	 * Return a timestamp as DateTime object.
-	 * 
+	 *
 	 * @param  string  $key
 	 * @return DateTime
 	 */
@@ -546,10 +546,10 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 			return $value;
 		}
 	}
-	
+
 	/**
 	 * Get the format for databsae stored dates.
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function getDateFormat()
@@ -821,7 +821,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 			}
 		}
 
-		return $attributes;		
+		return $attributes;
 	}
 
 	/**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -97,8 +97,8 @@ class EloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->exists = true;
 		$this->assertTrue($model->save());
 	}
-	
-	
+
+
 	public function testTimestampsAreReturnedAsObjects()
 	{
 		$model = $this->getMock('Illuminate\Database\Eloquent\Model', array('getDateFormat'));
@@ -107,7 +107,7 @@ class EloquentModelTest extends PHPUnit_Framework_TestCase {
 			'created_at'	=> '2012-12-04',
 			'updated_at'	=> '2012-12-05',
 		));
-		
+
 		$this->assertInstanceOf('DateTime', $model->created_at);
 		$this->assertInstanceOf('DateTime', $model->updated_at);
 	}


### PR DESCRIPTION
Eloquent's Timestamp-Getters omitted to return a value when dealing with DateTime Objects.

This produced empty Timestamp Attributes  when dealing with the $model instances returned after inserting a new record:

``` php
$user = array('username' => 'test', 'email' => 'test@test.com');
$created = User::create($user);

// returns NULL / false
var_dump($created->created_at):
// returns NULL / false
var_dump($created->updated_at): 
```

Full example here: http://paste.laravel.com/eQ5

This PR fixes the issue and adds a new test.
