### PR TITLE
Fixing inconsistency with asDateTime()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -545,16 +545,18 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	protected function asDateTime($key)
 	{
-		$value = $this->attributes[$key];
-
-		if ( ! $value instanceof DateTime)
+		if (isset($this->attributes[$key]) and $value = $this->attributes[$key])
 		{
-			$format = $this->getDateFormat();
 
-			return DateTime::createFromFormat($format, $value);
+			if ( ! $value instanceof DateTime)
+			{
+				$format = $this->getDateFormat();
+
+				return DateTime::createFromFormat($format, $value);
+			}
+
+			return $value;
 		}
-
-		return $value;
 	}
 
 	/**


### PR DESCRIPTION
All other fields in Eloquent will return NULL if they're not set, however asDateTime() returns a timestamp - http://d.pr/i/r6pm

I have fixed so a value is only returned as a timestamp if the field is actually set.
