### PR TITLE
Adding a default to the table prefix to remove the requirement of specifying one.

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -16,6 +16,11 @@ class ConnectionFactory {
 	 */
 	public function make(array $config)
 	{
+		if ( ! isset($config['prefix']))
+		{
+			$config['prefix'] = '';
+		}
+
 		$pdo = $this->createConnector($config)->connect($config);
 
 		return $this->createConnection($config['driver'], $pdo, $config['database'], $config['prefix']);
@@ -61,7 +66,7 @@ class ConnectionFactory {
 	 * @param  string  $tablePrefix
 	 * @return Illuminate\Database\Connection
 	 */
-	protected function createConnection($driver, PDO $connection, $database, $tablePrefix)
+	protected function createConnection($driver, PDO $connection, $database, $tablePrefix = '')
 	{
 		switch ($driver)
 		{


### PR DESCRIPTION
This is quite annoying, and most people will not use this feature, so why make it a requirement?
