### PR TITLE
Fix setting "date" Attributes in Eloquent Model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -926,7 +926,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		{
 			if ($value)
 			{
-				$this->attributes[$key] = $this->fromDateTime($value);
+				return $this->attributes[$key] = $this->fromDateTime($value);
 			}
 		}
 


### PR DESCRIPTION
Prevents `$this->attributes[$key]` from being overwritten by [Line 933](https://github.com/illuminate/database/blob/master/src/Illuminate/Database/Eloquent/Model.php#L933) with the original DateTime Object.
