### PR TITLE
Added Comment Modifier to Mysql Grammar

### DIFF
--- a/Schema/Grammars/MySqlGrammar.php
+++ b/Schema/Grammars/MySqlGrammar.php
@@ -17,7 +17,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After');
+	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After', 'Comment');
 
 	/**
 	 * Compile the query to determine if a table exists.
@@ -435,6 +435,18 @@ class MySqlGrammar extends Grammar {
 		{
 			return ' after '.$this->wrap($column->after);
 		}
+	}
+
+	/**
+	 * Get the SQL for a comment column modifier.
+	 *
+	 * @param  Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function modifyComment(Blueprint $blueprint, Fluent $column)
+	{
+		return $column->comment ? " comment '{$column->comment}'" : '';
 	}
 
 }


### PR DESCRIPTION
Hi Taylor,

Love your work Laravel is just awesome!!

I really care about documentation and always find my adding comments in the comments column in mysql

Till now I would do something like this

``` php
Schema::create('users', function($table) {
            $table->integer('extranet_id')->nullable()
        });

DB::update("ALTER TABLE `users` CHANGE `extranet_id` `extranet_id` INT(255)  COMMENT 'Comment about the field here!'");
```

This seems like double work. 

So I have created a fork and added this functionality, please review and merge if all ok.

Now you can do something like this.

``` php
Schema::create('users', function($table) {
            $table->integer('extranet_id')->nullable()->comment('Comment about the field here!');
        });
```

I also created a test but cant seem to find where to put it. There is no tests folder or repo?

Here is the test

``` php
    public function testAddingComment()
    {
        $blueprint = new Blueprint('users');
        $blueprint->string('foo')->comment('foo');
        $statements = $blueprint->toSql($this->getGrammar());

        $this->assertEquals(1, count($statements));
        $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'foo'", $statements[0]);
    }
```

Lastly I will also update the documentation when you merge the change.

Sorry I didn't update the other grammars as I not familiar with their syntax.
