### PR TITLE
Update Builder.php to correct a bug in the exists function.

### DIFF
--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -34,6 +34,7 @@ class Builder {
 	protected $passthru = array(
 		'lists', 'insert', 'insertGetId', 'update', 'delete', 'increment',
 		'decrement', 'pluck', 'count', 'min', 'max', 'avg', 'sum', 'exists',
+		'toSql',
 	);
 
 	/**


### PR DESCRIPTION
Update to correct a bug when using the exists function within a Model object. 
Example: when using User::where('id', '>', '0')->exists() it was returning a Builder object. With this change we can know get the boolean value as expected.
