### PR TITLE
Fix : Count records when I use groupby to primary key and join together.

### DIFF
--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -1264,6 +1264,10 @@ class Builder {
 		// the aggregate value getting in the way when the grammar builds it.
 		$this->aggregate = null;
 
+		if(count($this->groups) > 0 && count($this->joins) > 0 && count($results) > 1) {
+			return count($results);
+		}
+
 		if (isset($results[0]))
 		{
 			$result = (array) $results[0];


### PR DESCRIPTION
Example my code
$total = ProductBrand::join('products', 'products.product_brand_id','=','product_brands.id', 'left')
            ->where('product_brands.profile_id' , '=', $profile->getKey())
            ->whereNull('products.deleted_at')
            ->select('product_brands.id as id', 'product_brands.title as title', DB::raw('COUNT(products.id) as products'), 'product_brands.status', 'product_brands.updated_at')
            ->groupBy('product_brands.id')
            ->count();

Table structure:
- product_brands
  id, title, body, status, created_at, updated_at, deleted_at
- products
  id, product_brand_id, title, body, created_at, updated_at, deleted_at

Value that should return to $total in my case is 70 but I got 1. When I check $results in aggregate() method. I found array 70 items with key name 'aggregate' and value is '1'.

I know that my query isn't correct way but It's really important to use this because it use with Datatable package. https://packagist.org/packages/bllim/datatables.
