### PR TITLE
Eloquent dirty attributes can sometimes contain unchanged values due to identical check.

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -2165,7 +2165,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])
+			if ( ! array_key_exists($key, $this->original) or $value != $this->original[$key])
 			{
 				$dirty[$key] = $value;
 			}


### PR DESCRIPTION
An identical check here causes the dirty attributes array to sometimes (or often, from my tests) contain unchanged fields, such as comparing foreign keys which could be a string and an int of the same value.

The other alternative to this would be ensuring any attributes are always cast as the same type, however this should probably be done within the model rather than relying on the user input.
