### PR TITLE
Remove a previously added column

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -737,6 +737,21 @@ class Blueprint {
 
 		return $column;
 	}
+	
+	/**
+	 * Remove a column from the blueprint.
+	 *
+	 * @param  string  $name
+	 */
+	public function removeColumn($name)
+	{
+		foreach($this->columns as $index => $col){
+			if($col['attributes']['name'] === $name){
+				unset($this->columns[$index]);
+			}
+		}
+		return $this;
+	}
 
 	/**
 	 * Add a new command to the blueprint.


### PR DESCRIPTION
Sometimes when building structure on class inheritance I wished for changing a column propertie just like this:

```
$table->removeColumn('published')
      ->boolean('published')->default(false);
```

So published wish had default 'true' now can be changed to false, and I can inherit all the other fields from the parent class.
