### PR TITLE
Modify BelongsToMany::attach() to return boolean results

### DIFF
--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -662,7 +662,7 @@ class BelongsToMany extends Relation {
 	 * @param  mixed  $id
 	 * @param  array  $attributes
 	 * @param  bool   $touch
-	 * @return void
+	 * @return bool
 	 */
 	public function attach($id, array $attributes = array(), $touch = true)
 	{
@@ -670,9 +670,11 @@ class BelongsToMany extends Relation {
 
 		$query = $this->newPivotStatement();
 
-		$query->insert($this->createAttachRecords((array) $id, $attributes));
+		$success = $query->insert($this->createAttachRecords((array) $id, $attributes));
 
-		if ($touch) $this->touchIfTouching();
+		if ($success && $touch) $this->touchIfTouching();
+
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
Rather than resort to throwing an exception and requiring ugly application-level code to deal with it, we return the result of the attach in all cases.

Note that this also removes the `touchIfTouching()` call on failed inserts, which may be troublesome if the user is manually editing database records.
