### PR TITLE
Add getter for loggingQueries

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -919,6 +919,16 @@ class Connection implements ConnectionInterface {
 	}
 
 	/**
+	 * Determine whether we're logging queries.
+	 *
+	 * @return bool
+	 */
+	public function getQueryLogState()
+	{
+		return $this->loggingQueries;
+	}
+
+	/**
 	 * Get the name of the connected database.
 	 *
 	 * @return string


### PR DESCRIPTION
We currently have `DB::disableQueryLog();` and `DB::enableQueryLog();` but no `DB::getQueryLogState();` (`getQueryLog()` is already taken up for something unrelated).

Having this getter would allow developers to disable query log for DB-intensive operations then return logging to its previous state instead of having to guess what it was beforehand and setting to that.
