### PR TITLE
Implement toRawArray and toRawJson

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -2078,6 +2078,17 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Convert the model instance to JSON without visible and hidden filter.
+	 *
+	 * @param  int  $options
+	 * @return string
+	 */
+	public function toRawJson($options = 0)
+	{
+		return json_encode($this->toRawArray(), $options);
+	}
+
+	/**
 	 * Convert the object into something JSON serializable.
 	 *
 	 * @return array
@@ -2085,6 +2096,30 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public function jsonSerialize()
 	{
 		return $this->toArray();
+	}
+
+	/**
+	 * Convert the model instance to an array without visible or hidden filter
+	 * @return array
+	 */
+	public function toRawArray()
+	{
+		$savedHidden  = $this->hidden;
+		$savedVisible = $this->visible;
+
+		// Reset
+		$this->setVisible(array());
+		$this->setHidden(array());
+
+		$attributes = $this->attributesToArray();
+
+		$rawArray = array_merge($attributes, $this->relationsToArray());
+
+		// Reset
+		$this->setVisible($savedHidden);
+		$this->setHidden($savedVisible);
+
+		return $rawArray;
 	}
 
 	/**


### PR DESCRIPTION
Sometime we need to get an array of all attributes, but we want to keep clean method for `toArray`.

``` php
class test extends Illuminate\Database\Eloquent\Model
{
    protected $visible = ['ddd'];
    protected $hidden = ['bbb'];
}

$d = new test();
$d->ddd = 'bisous';
$d->bbb = 'bisousbbb';
$d->machin = 'truc';

echo json_encode($d->toRawArray()); // {"ddd":"bisous","bbb":"bisousbbb","machin":"truc"}
echo json_encode($d->toArray()); // {"bbb":"bisousbbb"}
```
