### PR TITLE
Please revert breaking change in Illuminate\Database\Eloquent::performUpdate()

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -1450,6 +1450,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 				$this->fireModelEvent('updated', false);
 			}
+
+			return true;
 		}
 
 		return true;


### PR DESCRIPTION
This PR reverts two bad commits that constitute breaking changes and were pushed back to 4.0 and 4.1, and adds in one good change from the first commit.

The problem is the assertion that  "performUpdate should return false if no update is performed". This is debatable at best, and is a clear breaking change for vanilla use cases.

Here's a typical resource controller's update handler:

``` php
<?php

$success = $model->update($fillable_fields);

if ($success) {
 // ...manually update unfillable fields
 // ...manually update complex relations
 // ...and so on
}
```

Although a possible workaround is

``` php
<?php

if ($success !== false) {
  // ...
}
```

it's atypical to have to be this specific, and the real problem is that an update that doesn't actually update database columns is (conceptually) vacuously successful in typical application architecture. A much better design is:

``` php
<?php

if ($success === true) {
  // ...
}
```

Basically, my assertion is that Illuminate\Database\Eloquent::performUpdate() should return a boolean, and it should return true iff the update did not fail.
