### PR TITLE
Added support for sslmode to PostgreSQL connector.

### DIFF
--- a/Connectors/PostgresConnector.php
+++ b/Connectors/PostgresConnector.php
@@ -75,6 +75,16 @@ class PostgresConnector extends Connector implements ConnectorInterface {
 			$dsn .= ";port={$port}";
 		}
 
+		// If sslmode was specified, add it to this Postgres DSN connections
+		// format. This setting will turn on/off the encryption of the connection
+		// between the app and database. Set it to 'require' to ensure encrypted 
+		// connection. Possible values depend on the version of the pgsql library:
+		// 'disable', 'prefer', 'require', 'verify-ca', 'verify-full' 
+		if (isset($config['sslmode']))
+		{
+			$dsn .= ";sslmode={$sslmode}";
+		}
+
 		return $dsn;
 	}
 


### PR DESCRIPTION
This change makes it specify sslmode when connecting to PostgreSQL. Of course this requires some configuration of PostgreSQL to make it work. I've tested this with the database config value 'require' to make SSL connection mandatory. Other values depends on the pgsql library in use. 

As of verson 9.3 there exists a handfull of sslmodes:
http://www.postgresql.org/docs/9.3/static/libpq-ssl.html
