### PR TITLE
Adds better interoperatibility with Twig

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -3351,8 +3351,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		}
 
 		$query = $this->newQuery();
-
-		return call_user_func_array(array($query, $method), $parameters);
+		if(method_exists($query, $method))
+		{
+			return call_user_func_array(array($query, $method), $parameters);
+		}
 	}
 
 	/**


### PR DESCRIPTION
When creating a brand new Model, and rendering its dynamic properties using Twig, an exception will be thrown (BadMethodCallException). 