### PR TITLE
Make sure getRan() returns migrations in proper order.

### DIFF
--- a/Migrations/DatabaseMigrationRepository.php
+++ b/Migrations/DatabaseMigrationRepository.php
@@ -45,7 +45,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function getRan()
 	{
-		return $this->table()->lists('migration');
+		$results = $this->table()->orderBy('migration', 'asc')->get(['migration']);
+
+		return array_pluck($results, 'migration');
 	}
 
 	/**


### PR DESCRIPTION
This change makes sure that migrations are returned in order they were (supposed to be) created. Simple lists() does not work here as some databases do not return entries in the same order all of the time. 

Without that change artisan migration:reset can fail randomly. migration:reset uses this function from v5.0.28.