### PR TITLE
Batch insert correction

### DIFF
--- a/Query/Grammars/Grammar.php
+++ b/Query/Grammars/Grammar.php
@@ -624,12 +624,10 @@ class Grammar extends BaseGrammar {
 
 		$columns = $this->columnize(array_keys(reset($values)));
 
-		// We need to build a list of parameter place-holders of values that are bound
-		// to the query. Each insert should have the exact same amount of parameter
-		// bindings so we can just go off the first list of values in this array.
-		$parameters = $this->parameterize(reset($values));
-
-		$value = array_fill(0, count($values), "($parameters)");
+		$value = [];
+		foreach($values as &$record) {
+			$value[] =  '(' . $this->parameterize($record) . ')';
+		}
 
 		$parameters = implode(', ', $value);
 


### PR DESCRIPTION
No longer uses the first element to define the values of all inserting
records.  This was a bug because if one of the parameters was an expression then
the same expression value would be inserted for all records.