### PR TITLE
fix bug on MySQL for default values

### DIFF
--- a/Schema/Grammars/MySqlGrammar.php
+++ b/Schema/Grammars/MySqlGrammar.php
@@ -532,7 +532,7 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeTimestamp(Fluent $column)
 	{
-		if ( ! $column->nullable) return 'timestamp default 0';
+		if ( ! $column->nullable) return 'timestamp default CURRENT_TIMESTAMP';
 
 		return 'timestamp';
 	}


### PR DESCRIPTION
I have noticed this error when try to migrate a table in Laravel with timestamp with no default value, my propose to fix this is, if is not set, set the default value to the cuerrent timestamp, the code I use is like:

$table->timestamp('created_at');

and the error I noticed is like this:

[Illuminate\Database\QueryException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at' (SQL: create table `users` (`id` int unsigned not null

auto_increment primary key, `name` varchar(255) not null, `email` varchar(2

55) not null, `password` varchar(60) not null, `remember_token` varchar(100

) null, `created_at` timestamp default 0 not null, `updated_at` timestamp d

efault 0 not null) default character set utf8 collate utf8_unicode_ci)

[PDOException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at'