### PR TITLE
`lists` method should be consistent

### DIFF
--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -248,7 +248,7 @@ class Builder
             }
         }
 
-        return $results;
+        return collect($results);
     }
 
     /**


### PR DESCRIPTION
When calling `lists` method on a collection it returns a new collection.
It would be great if they both return a `new Collection` and be
consistent.