### PR TITLE
Add path for the database that we tried to load

### DIFF
--- a/Connectors/SQLiteConnector.php
+++ b/Connectors/SQLiteConnector.php
@@ -31,7 +31,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // as the developer probably wants to know if the database exists and this
         // SQLite driver will not throw any exception if it does not by default.
         if ($path === false) {
-            throw new InvalidArgumentException('Database does not exist.');
+            throw new InvalidArgumentException("Database (${config['database']}) does not exist.");
         }
 
         return $this->createConnection("sqlite:{$path}", $config, $options);


### PR DESCRIPTION
Without this information the exception isn't very helpful as the developer will have no idea where Illuminate was searching.