### PR TITLE
Use provided ID for FindOrNew

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -681,7 +681,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $model;
         }
 
-        return new static;
+        $model = new static;
+        
+        $model->_id = $id
+        
+        return $model
     }
 
     /**


### PR DESCRIPTION
With FindOrNew, in the case of a model not being found, the primary key provided should be the one used in the construction of a new model