### PR TITLE
improvement proposal for firstOrCreate/firstOrNew method in Eloquent Model

### DIFF
--- a/Capsule/Manager.php
+++ b/Capsule/Manager.php
@@ -6,9 +6,9 @@ use PDO;
 use Illuminate\Container\Container;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Traits\CapsuleManagerTrait;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Connectors\ConnectionFactory;
-use Illuminate\Support\Traits\CapsuleManagerTrait;
 
 class Manager
 {

--- a/Connection.php
+++ b/Connection.php
@@ -506,7 +506,7 @@ class Connection implements ConnectionInterface
         if ($this->transactions == 1) {
             $this->pdo->beginTransaction();
         } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {
-            $this->statement(
+            $this->pdo->exec(
                 $this->queryGrammar->compileSavepoint('trans'.$this->transactions)
             );
         }
@@ -540,7 +540,7 @@ class Connection implements ConnectionInterface
         if ($this->transactions == 1) {
             $this->pdo->rollBack();
         } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {
-            $this->statement(
+            $this->pdo->exec(
                 $this->queryGrammar->compileSavepointRollBack('trans'.$this->transactions)
             );
         }

--- a/Eloquent/Collection.php
+++ b/Eloquent/Collection.php
@@ -208,6 +208,21 @@ class Collection extends BaseCollection
     }
 
     /**
+     * Make the given, typically hidden, attributes visible across the entire collection.
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function withHidden($attributes)
+    {
+        $this->each(function ($model) use ($attributes) {
+            $model->withHidden($attributes);
+        });
+
+        return $this;
+    }
+
+    /**
      * Get a dictionary keyed by primary keys.
      *
      * @param  \ArrayAccess|array  $items

--- a/Eloquent/FactoryBuilder.php
+++ b/Eloquent/FactoryBuilder.php
@@ -124,7 +124,7 @@ class FactoryBuilder
     {
         return Model::unguarded(function () use ($attributes) {
             if (! isset($this->definitions[$this->class][$this->name])) {
-                throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
+                throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
             }
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);

--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -655,7 +655,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get all of the models from the database.
      *
-     * @param  array  $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Collection|static[]
      */
     public static function all($columns = ['*'])
@@ -1356,7 +1356,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Add an observable event name.
      *
-     * @param  mixed  $observables
+     * @param  array|mixed  $observables
      * @return void
      */
     public function addObservableEvents($observables)
@@ -1369,7 +1369,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Remove an observable event name.
      *
-     * @param  mixed  $observables
+     * @param  array|mixed  $observables
      * @return void
      */
     public function removeObservableEvents($observables)

--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -888,7 +888,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getActualClassNameForMorph($class)
     {
-        return array_get(Relation::morphMap(), $class, $class);
+        return Arr::get(Relation::morphMap(), $class, $class);
     }
 
     /**

--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -749,7 +749,7 @@ class BelongsToMany extends Relation
     /**
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
-     * @param  array  $ids
+     * @param  \Illuminate\Database\Eloquent\Collection|array  $ids
      * @param  bool   $detaching
      * @return array
      */

--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -528,7 +528,7 @@ class BelongsToMany extends Relation
     /**
      * Get all of the IDs for the related models.
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function getRelatedIds()
     {

--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -1142,7 +1142,7 @@ class BelongsToMany extends Relation
     /**
      * Set the columns on the pivot table to retrieve.
      *
-     * @param  mixed  $columns
+     * @param  array|mixed  $columns
      * @return $this
      */
     public function withPivot($columns)

--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -731,7 +731,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $records
      * @param  array  $joinings
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return array
      */
     public function createMany(array $records, array $joinings = [])
     {

--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -1589,6 +1589,7 @@ class Builder
     public function exists()
     {
         $sql = $this->grammar->compileExists($this);
+
         $results = $this->connection->select($sql, $this->getBindings(), ! $this->useWritePdo);
 
         if (isset($results[0])) {

--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -1512,7 +1512,7 @@ class Builder
      *
      * @param  int  $count
      * @param  callable  $callback
-     * @return void
+     * @return bool
      */
     public function chunk($count, callable $callback)
     {
@@ -1523,13 +1523,15 @@ class Builder
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
             if (call_user_func($callback, $results) === false) {
-                break;
+                return false;
             }
 
             $page++;
 
             $results = $this->forPage($page, $count)->get();
         }
+
+        return true;
     }
 
     /**

--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -1668,7 +1668,7 @@ class Builder
      */
     public function average($column)
     {
-        return $this->avg($key);
+        return $this->avg($column);
     }
 
     /**

--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -224,7 +224,7 @@ class Builder
     /**
      * Set the columns to be selected.
      *
-     * @param  array  $columns
+     * @param  array|mixed  $columns
      * @return $this
      */
     public function select($columns = ['*'])
@@ -283,7 +283,7 @@ class Builder
     /**
      * Add a new select column to the query.
      *
-     * @param  mixed  $column
+     * @param  array|mixed  $column
      * @return $this
      */
     public function addSelect($column)

--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -1659,6 +1659,17 @@ class Builder
     }
 
     /**
+     * Alias for the "avg" method.
+     *
+     * @param  string  $column
+     * @return float|int
+     */
+    public function average($column)
+    {
+        return $this->avg($key);
+    }
+
+    /**
      * Execute an aggregate function on the database.
      *
      * @param  string  $function

--- a/Query/Grammars/SQLiteGrammar.php
+++ b/Query/Grammars/SQLiteGrammar.php
@@ -74,6 +74,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDate(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%Y-%m-%d', $query, $where);
+    }
+
+    /**
      * Compile a "where day" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -203,7 +203,7 @@ class Blueprint
     /**
      * Indicate that the given columns should be dropped.
      *
-     * @param  string|array  $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Support\Fluent
      */
     public function dropColumn($columns)


### PR DESCRIPTION
Hi,

First, I hope I do it the right way at it's my first pull request ever (I may be wrong somewhere).

The methods firstOrCreate/firstOrNew only enable to select on the very same fields as the ones used to insert. I think it would be usefull to make,

1. a select with a "where" condition on some fields
2. and eventually insert with other fields. 

This is the proposal to replace the method firstOrCreate (the same would apply for firstOrNew) :

    public static function firstOrCreate(array $whereAttrs, array $insertAttrs = [])
    {
        if (! is_null($instance = static::where($whereAttrs)->first())) {
            return $instance;
        }

        return empty($insertAttrs) ? static::create($whereAttrs) : static::create($insertAttrs);
    }

I'm no code genius so I hope I'm not saying nonsense. What do you think?