### PR TITLE
Update Collection.php

### DIFF
--- a/Eloquent/Collection.php
+++ b/Eloquent/Collection.php
@@ -104,8 +104,8 @@ class Collection extends BaseCollection
     {
         $dictionary = $this->getDictionary();
 
-        foreach ($items as $item) {
-            $dictionary[$item->getKey()] = $item;
+        foreach ($items as $key => $item) {
+            $dictionary[$key] = $item;
         }
 
         return new static(array_values($dictionary));
@@ -123,8 +123,8 @@ class Collection extends BaseCollection
 
         $dictionary = $this->getDictionary($items);
 
-        foreach ($this->items as $item) {
-            if (! isset($dictionary[$item->getKey()])) {
+        foreach ($this->items as $key => $item) {
+            if (! isset($dictionary[$key])) {
                 $diff->add($item);
             }
         }
@@ -144,8 +144,8 @@ class Collection extends BaseCollection
 
         $dictionary = $this->getDictionary($items);
 
-        foreach ($this->items as $item) {
-            if (isset($dictionary[$item->getKey()])) {
+        foreach ($this->items as $key => $item) {
+            if (isset($dictionary[$key])) {
                 $intersect->add($item);
             }
         }
@@ -221,8 +221,8 @@ class Collection extends BaseCollection
 
         $dictionary = [];
 
-        foreach ($items as $value) {
-            $dictionary[$value->getKey()] = $value;
+        foreach ($items as $key => $value) {
+            $dictionary[$key] = $value;
         }
 
         return $dictionary;


### PR DESCRIPTION
Using `$key => $value` convention in foreach to avoid having to call `$item->getKey()` on types that might not have that method such as doubles.