### PR TITLE
Prioritize Eloquent dateFormat when set

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -2943,6 +2943,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return Carbon::instance($value);
         }
 
+        // If the dateFormat has been set for this model, prioritize it
+        if ($this->dateFormat) {
+            return Carbon::createFromFormat($this->dateFormat, $value);
+        }
+
         // If this value is an integer, we will assume it is a UNIX timestamp's value
         // and format a Carbon object from this timestamp. This allows flexibility
         // when defining your date fields as they might be UNIX timestamps here.


### PR DESCRIPTION
If the dateFormat is set by the model to 'Ymd', for example, it is numeric and passes the timestamp test at line 2954. I think if the dateFormat is set, it should be prioritized over type and regular expression matching.

Currently, it parses a date like 20151116 as a timestamp and when that date is written to a view you will get 08/22/1970, even if you have set the dateFormat to Ymd.