### PR TITLE
Add DateTimeImmutable as a valid date object to Model.php

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use Closure;
 use DateTime;
+use DateTimeImmutable;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
@@ -2965,7 +2966,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If the value is already a DateTime instance, we will just skip the rest of
         // these checks since they will be a waste of time, and hinder performance
         // when checking the field. We will just return the DateTime right away.
-        if ($value instanceof DateTime) {
+        if ($value instanceof DateTime || $value instanceof DateTimeImmutable) {
             return Carbon::instance($value);
         }
 


### PR DESCRIPTION
DateTimeImmutable behaves just like the DateTime object, so it should be considered as a valid date object when returning a Carbon DateTime object.
See [PHP DateTimeImmutable reference](http://php.net/manual/en/class.datetimeimmutable.php) for more info about DateTimeImmutable.