### PR TITLE
Store unicode more compact

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -3048,7 +3048,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return json_encode($value, JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
Now casted arrays are saved with escaped unicode in database what makes them huge when some languages are used. Fix it please.