### PR TITLE
Allow updates on JOINs

### DIFF
--- a/Query/Grammars/Grammar.php
+++ b/Query/Grammars/Grammar.php
@@ -729,7 +729,7 @@ class Grammar extends BaseGrammar
         $columns = [];
 
         foreach ($values as $key => $value) {
-            $columns[] = $this->wrap($key).' = '.$this->parameter($value);
+            $columns[] = $table.' . '.$this->wrap($key).' = '.$this->parameter($value);
         }
 
         $columns = implode(', ', $columns);


### PR DESCRIPTION
Using Laravel 5.1 "touches" feature, an update on a JOIN was created, with two tables containing the same column (updated_at). This caused a SQL error.

The query showed that the updated_at is not being prefixed by the table name that's being updated. Easy fix is to simply add the table name, to be explicit on what table's field is being updated.

I tested this in my Laravel application, and everything seems to work as expected.
