### PR TITLE
use relation name instead of pivot

### DIFF
--- a/Eloquent/Relations/BelongsToMany.php
+++ b/Eloquent/Relations/BelongsToMany.php
@@ -294,7 +294,7 @@ class BelongsToMany extends Relation
         foreach ($models as $model) {
             $pivot = $this->newExistingPivot($this->cleanPivotAttributes($model));
 
-            $model->setRelation('pivot', $pivot);
+            $model->setRelation($this->getRelationName(), $pivot);
         }
     }
 


### PR DESCRIPTION
Use relation name which is set by fifth parameter of method Model::belongsToMany() instead of hardcoding 'pivot'