### PR TITLE
Update Connectors/Connector.php to use an Encrypted Password

### DIFF
--- a/Connectors/Connector.php
+++ b/Connectors/Connector.php
@@ -44,7 +44,7 @@ class Connector
      * @param  string  $dsn
      * @param  array   $config
      * @param  array   $options
-     * @param  array   $decrypt
+     * @param  mixed   $decrypt null | string which is the key for the encrypter
      * @return \PDO
      */
     public function createConnection($dsn, array $config, array $options, $decrypt = null)

--- a/Connectors/Connector.php
+++ b/Connectors/Connector.php
@@ -64,7 +64,7 @@ class Connector
             $pdo = new PDO($dsn, $username, $password, $options);
         } catch (Exception $e) {
             $pdo = $this->tryAgainIfCausedByLostConnection(
-                $e, $dsn, $username, (!is_null($decrypt) ? $passwordEncrypted : $password, $options
+                $e, $dsn, $username, (!is_null($decrypt)) ? $passwordEncrypted : $password, $options
             );
         }
 


### PR DESCRIPTION
Create a convention to that uses configuration key 'password_encrypted' which would contain an encrypted password generated from Encrypter class. This would reduce the risk of exposing a decrypted password if the object or configuration values were dumped.
