### PR TITLE
setupDefaultConfiguration only if not set $container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/container": "5.3.*",
-        "illuminate/contracts": "5.3.*",
-        "illuminate/support": "5.3.*",
+        "illuminate/container": "5.4.*",
+        "illuminate/contracts": "5.4.*",
+        "illuminate/support": "5.4.*",
         "nesbot/carbon": "~1.20"
     },
     "autoload": {
@@ -28,16 +28,16 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.3-dev"
+            "dev-master": "5.4-dev"
         }
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
-        "illuminate/console": "Required to use the database commands (5.3.*).",
-        "illuminate/events": "Required to use the observers with Eloquent (5.3.*).",
-        "illuminate/filesystem": "Required to use the migrations (5.3.*).",
-        "illuminate/pagination": "Required to paginate the result set (5.3.*)."
+        "illuminate/console": "Required to use the database commands (5.4.*).",
+        "illuminate/events": "Required to use the observers with Eloquent (5.4.*).",
+        "illuminate/filesystem": "Required to use the migrations (5.4.*).",
+        "illuminate/pagination": "Required to paginate the result set (5.4.*)."
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
play with multiple connections
```php
// Register Eloquent multiple connections
$elo_con = new \Illuminate\Container\Container();
$elo_con['config'] = [
  'database.connections' => $cfg['settings']['db']['connections'],
  'database.default' => $cfg['settings']['db']['default'],
  'database.fetch' => PDO::FETCH_OBJ
];
$capsule = new \Illuminate\Database\Capsule\Manager($elo_con);
$capsule->setAsGlobal();
$capsule->bootEloquent();
```

query:
```
$p = DB::connection('pgsql')->select('SELECT * FROM test');
$m = DB::connection('mysql')->select('SELECT * FROM `test_mysql` LIMIT 50');
```

works fine but annoying:
```
PHP Notice: Indirect modification of overloaded element of Illuminate\Container\Container has no effect in .../vendor/illuminate/database/Capsule/Manager.php:51
PHP Notice: Indirect modification of overloaded element of Illuminate\Container\Container has no effect in .../vendor/illuminate/database/Capsule/Manager.php:53
```

`Illuminate\Database\Capsule\Manager.php` something like this
```php
if(!$container) {
    $this->setupDefaultConfiguration();
}
```