### PR TITLE
Optional callback in 'whereHas'

### DIFF
--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -873,7 +873,7 @@ class Builder
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }


### PR DESCRIPTION
This was annoying me when using 'whereHas' - no callback appears to be strictly needed in 'has'.