### PR TITLE
[5.3][master] Fix misleading exception when ExceptionHandler is not bound in the container

### DIFF
--- a/Connectors/ConnectionFactory.php
+++ b/Connectors/ConnectionFactory.php
@@ -125,7 +125,7 @@ class ConnectionFactory
                 try {
                     return $this->createConnector($config)->connect($config);
                 } catch (PDOException $e) {
-                    if (count($hosts) - 1 === $key) {
+                    if (count($hosts) - 1 === $key && $this->container->bound(ExceptionHandler::class)) {
                         $this->container->make(ExceptionHandler::class)->report($e);
                     }
                 }


### PR DESCRIPTION
PR for https://github.com/laravel/framework/issues/16661