### PR TITLE
fix bug: connection error

### DIFF
--- a/DatabaseManager.php
+++ b/DatabaseManager.php
@@ -59,14 +59,14 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        list($name, $type) = $this->parseConnectionName($name);
+        list($databaseName, $type) = $this->parseConnectionName($name);
 
         // If we haven't created this connection, we'll create it based on the config
         // provided in the application. Once we've created the connections we will
         // set the "fetch mode" for PDO which determines the query return types.
         if (! isset($this->connections[$name])) {
             $this->connections[$name] = $this->configure(
-                $connection = $this->makeConnection($name), $type
+                $connection = $this->makeConnection($databaseName), $type
             );
         }
 


### PR DESCRIPTION
When your database is configured to read and write

```php
// If you do it first.
DB::table('test')->get();
/ / some other operation
//Last
DB::connection ('mysql::write')->table('detail')->get(); 
// The database link you are using in your query is still `read-only`.
```
