### PR TITLE
PHPDoc improvement

### DIFF
--- a/Eloquent/Relations/HasOneOrMany.php
+++ b/Eloquent/Relations/HasOneOrMany.php
@@ -207,7 +207,7 @@ abstract class HasOneOrMany extends Relation
      * Attach a model instance to the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Database\Eloquent\Model|false
      */
     public function save(Model $model)
     {


### PR DESCRIPTION
Correct return types of \Illuminate\Database\Eloquent\Relations\HasOneOrMany::save() are in phpDoc
 
'false' is an allowed type in phpdoc. see for reference: [The keyword section of the Type documentation of phpDocumentor](https://phpdoc.org/docs/latest/guides/types.html#keywords)