### PR TITLE
Added support for multiple paths for --path option

### DIFF
--- a/Console/Migrations/BaseCommand.php
+++ b/Console/Migrations/BaseCommand.php
@@ -17,7 +17,11 @@ class BaseCommand extends Command
         // use the path relative to the root of the installation folder so our database
         // migrations may be run for any customized path from within the application.
         if ($this->input->hasOption('path') && $this->option('path')) {
-            return [$this->laravel->basePath().'/'.$this->option('path')];
+            $paths = [];
+            foreach (explode(\PATH_SEPARATOR, $this->option('path')) as $path) {
+                $paths[] = $this->laravel->basePath().'/'.$path;
+            }
+            return $paths;
         }
 
         return array_merge(


### PR DESCRIPTION
It's required for `migrate:reset` if you run migrations from different paths:
```
./artisan migrate
./artisan migrate --path database/migrations/foodir1
./artisan migrate --path database/migrations/bardir2
```

`./artisan migrate:reset` will fail with something like this:
```
[ErrorException]
Undefined index: 2016_10_11_153917_some_migration_from_foodir1_or_bardir2
```

At the same time next code will work (with mine changes):
```
./artisan migrate:reset --path database/migrations:database/migrations/foodir1:database/migrations/bardir2
```