### PR TITLE
Fix “SQLSTATE[HY000]: General error: Third parameter not allowed for PDO::FETCH_COLUMN”

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -344,7 +344,7 @@ class Connection implements ConnectionInterface
             }
 
             if (isset($fetchArgument)) {
-                return ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN))
+                return ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN) || $fetchMode === ($fetchMode | PDO::FETCH_INFO))
                     ? $statement->fetchAll($fetchMode, $fetchArgument)
                     : $statement->fetchAll($fetchMode, $fetchArgument, $fetchConstructorArgument);
             } else {
@@ -380,7 +380,7 @@ class Connection implements ConnectionInterface
             }
 
             if (isset($fetchArgument)) {
-                ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN))
+                ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN) || $fetchMode === ($fetchMode | PDO::FETCH_INFO))
                     ? $statement->setFetchMode($fetchMode, $fetchArgument)
                     : $statement->setFetchMode($fetchMode, $fetchArgument, $fetchConstructorArgument);
             } else {

--- a/Connection.php
+++ b/Connection.php
@@ -343,9 +343,13 @@ class Connection implements ConnectionInterface
                 $fetchConstructorArgument = null;
             }
 
-            return isset($fetchArgument)
-                ? $statement->fetchAll($fetchMode, $fetchArgument, $fetchConstructorArgument)
-                : $statement->fetchAll($fetchMode);
+            if (isset($fetchArgument)) {
+                return ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN))
+                    ? $statement->fetchAll($fetchMode, $fetchArgument)
+                    : $statement->fetchAll($fetchMode, $fetchArgument, $fetchConstructorArgument);
+            } else {
+                return $statement->fetchAll($fetchMode);
+            }
         });
     }
 
@@ -376,7 +380,9 @@ class Connection implements ConnectionInterface
             }
 
             if (isset($fetchArgument)) {
-                $statement->setFetchMode($fetchMode, $fetchArgument, $fetchConstructorArgument);
+                ($fetchMode === ($fetchMode | PDO::FETCH_COLUMN))
+                    ? $statement->setFetchMode($fetchMode, $fetchArgument)
+                    : $statement->setFetchMode($fetchMode, $fetchArgument, $fetchConstructorArgument);
             } else {
                 $statement->setFetchMode($fetchMode);
             }

--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -3277,7 +3277,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getConnection()
     {
-        return static::resolveConnection($this->getConnectionName());
+        $connection = static::resolveConnection($this->getConnectionName());
+        $connection->setFetchMode(\PDO::FETCH_OBJ, null, []);
+        return $connection;
     }
 
     /**


### PR DESCRIPTION
When use PDO::FETCH_COLUMN fetch style and set the fetch argument, a exception will be thrown:
“SQLSTATE[HY000]: General error: Third parameter not allowed for PDO::FETCH_COLUMN”