### PR TITLE
unprepared return value bug fixed

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -490,7 +490,7 @@ class Connection implements ConnectionInterface
                 return true;
             }
 
-            return (bool) $this->getPdo()->exec($query);
+            return $this->getPdo()->exec($query) === false ? false : true;
         });
     }
 


### PR DESCRIPTION
PDO::exec() may return Boolean FALSE, but may also return a non-Boolean value which evaluates to FALSE.