### PR TITLE
Make HasAttributes::getDateFormat public

### DIFF
--- a/Eloquent/Concerns/HasAttributes.php
+++ b/Eloquent/Concerns/HasAttributes.php
@@ -781,7 +781,7 @@ trait HasAttributes
      *
      * @return string
      */
-    protected function getDateFormat()
+    public function getDateFormat()
     {
         return $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
     }


### PR DESCRIPTION
It doesn't really make sense to make the getter protected function if the setter is public.