### PR TITLE
Move morph relation morph type to first place in query

### DIFF
--- a/Eloquent/Relations/MorphOneOrMany.php
+++ b/Eloquent/Relations/MorphOneOrMany.php
@@ -90,9 +90,9 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(
-            $this->morphType, $this->morphClass
-        );
+        $query->where($this->morphType, $this->morphClass);
+
+        return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
     }
 
     /**


### PR DESCRIPTION
As discussed here: https://github.com/laravel/framework/issues/26720
Proposal to move entity name to first place in query builder.
This would fit current migration index design.