### PR TITLE
May be a bug: mysql connection bind float value as int

### DIFF
--- a/MySqlConnection.php
+++ b/MySqlConnection.php
@@ -77,7 +77,7 @@ class MySqlConnection extends Connection
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1, $value,
-                is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }


### PR DESCRIPTION
I can't insert a float value into mysql database because of this little bug.