### PR TITLE
Bugfix for self-referencing polymorphic relationships

### DIFF
--- a/Eloquent/Relations/MorphOneOrMany.php
+++ b/Eloquent/Relations/MorphOneOrMany.php
@@ -80,7 +80,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getMorphType()} = $this->morphClass;
     }
 
-    /**
+/**
      * Get the relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -90,6 +90,13 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
+        if ($query->getQuery()->from == $parentQuery->getQuery()->from) {
+            $query = parent::getRelationExistenceQuery($query, $parentQuery, $columns);
+            return $query->where(
+                $query->getModel()->getTable().'.'.$this->getMorphType(), $this->morphClass
+            );
+        }
+
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(
             $this->morphType, $this->morphClass
         );


### PR DESCRIPTION
Bug: When a model has a polymorphic relationship with itself the withCount() function always returns 0.

Analysis: The HasOneOrMany::getRelationExistenceQuery() method has separate logic for self referencing relationships, but the MorphOneOrMany::getRelationExistenceQuery() function doesn't. This causes part of the query to point to the Model itself instead of the relation leading to the resulting count being always 0.

Solution: Modified MorphOneOrMany::getRelationExistenceQuery() to accommodate self-referencing relationships.