### PR TITLE
adjust the default created_at and updated_at

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -981,9 +981,11 @@ class Blueprint
      */
     public function timestamps($precision = 0)
     {
-        $this->timestamp('created_at', $precision)->nullable();
-
-        $this->timestamp('updated_at', $precision)->nullable();
+        $table->timestamp('created_at', $precision)->useCurrent();
+        
+        $table->timestamp('updated_at', $precision)->default(
+                DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+            );
     }
 
     /**


### PR DESCRIPTION
Excuse me. I worried that there are operations that directly modify the table, bypassing the update of the model, causing created_at and updated_at not to update.