### PR TITLE
set charset

### DIFF
--- a/Connectors/MySqlConnector.php
+++ b/Connectors/MySqlConnector.php
@@ -129,9 +129,13 @@ class MySqlConnector extends Connector implements ConnectorInterface
     {
         extract($config, EXTR_SKIP);
 
-        return isset($port)
+        $dsn = isset($port)
                     ? "mysql:host={$host};port={$port};dbname={$database}"
                     : "mysql:host={$host};dbname={$database}";
+        if (isset($charset)) {
+            $dsn .= ";charset={$charset}";
+        }
+        return $dsn;
     }
 
     /**


### PR DESCRIPTION
My database is `mysql8`.
And there's an exception when `$connection = $this->createConnection($dsn, $config, $options);`
so we need set charset befor create a connection.
*****
## The exception
`Uncaught PDOException: SQLSTATE[HY000] [1045] client charset is not supported`