### PR TITLE
Limited morph properties by type

### DIFF
--- a/Eloquent/Relations/MorphTo.php
+++ b/Eloquent/Relations/MorphTo.php
@@ -43,6 +43,13 @@ class MorphTo extends BelongsTo
      * @var array
      */
     protected $morphableEagerLoads = [];
+    
+    /**
+     * A map of model type properties to show on individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableProperties = [];
 
     /**
      * Create a new morph to relationship instance.
@@ -122,6 +129,10 @@ class MorphTo extends BelongsTo
                                 $this->getQuery()->getEagerLoads(),
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
                             ));
+        
+        if(!empty($this->morphableProperties[get_class($instance)])) {
+            $query->select($this->morphableProperties[get_class($instance)]);
+        }
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
 
@@ -273,6 +284,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoads = array_merge(
             $this->morphableEagerLoads, $with
+        );
+
+        return $this;
+    }
+    
+    /**
+     * Specify which properties to load for a given morph type.
+     *
+     * @param  array  $properties
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function morphProperties(array $properties)
+    {
+        $this->morphableProperties = array_merge(
+            $this->morphableProperties, $properties
         );
 
         return $this;


### PR DESCRIPTION
This is a functionality to allow a query like "morphWith" but named "morphProperties" to limit the properties of morph by type.

```
$recommendations = Recommendation::with(['recommendable' => function (MorphTo $morphTo) {
    // This limit the properties showed for morph type
    $morphTo->morphProperties([
        User::class => ['id', 'username'],
        UserVacantion::class => ['id', 'user_id'],
    ]);

    // This eager load some relationships for morph type
    $morphTo->morphWith([
        User::class => [],
        UserVacantion::class => ['user:id,username'],
    ]);
}])->get();
```