### PR TITLE
add support for getOrFail() 

### DIFF
--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -527,6 +527,29 @@ class Builder
         return $builder->getModel()->newCollection($models);
     }
 
+
+    /**
+     * Execute the query as a "select" statement or throw an exception.
+     *
+     * @param array|string $columns
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function getOrFail($columns = ['*'])
+    {
+
+        $models = $this->get($columns);
+
+        // If any models exist
+        if (count($models)) {
+            return $models;
+        }
+
+        throw (new ModelNotFoundException)->setModel(get_class($this->model));
+
+    }
+
     /**
      * Get the hydrated models without eager loading.
      *

--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -538,7 +538,6 @@ class Builder
      */
     public function getOrFail($columns = ['*'])
     {
-
         $models = $this->get($columns);
 
         // If any models exist
@@ -547,7 +546,6 @@ class Builder
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model));
-
     }
 
     /**


### PR DESCRIPTION
get() method returns an empty collection if there are not any models. 
in some cases I've faced, i.e in API responses, It would be useful to throw an exception for empty query results.