### PR TITLE
Add indices to "deleted_at" column by default

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -1138,7 +1138,7 @@ class Blueprint
      */
     public function softDeletes($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestamp($column, $precision)->nullable();
+        return $this->timestamp($column, $precision)->nullable()->index();
     }
 
     /**
@@ -1150,7 +1150,7 @@ class Blueprint
      */
     public function softDeletesTz($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestampTz($column, $precision)->nullable();
+        return $this->timestampTz($column, $precision)->nullable()->index();
     }
 
     /**


### PR DESCRIPTION
The column `deleted_at` added via `softDeletes` (or `softDeletesTz`) is included in the `WHERE` clause (by default) and checks if the value is `NULL` or not.

This adds a lot of load on queries that do not have any explicit index applied on the `deleted_at` column, and is usually skipped by new (and even some seasoned) developers.

The column must be indexed, if it is going to be included by default in the query as one of the `WHERE` condition.