### PR TITLE
Change to `union` instead of `merge`

### DIFF
--- a/Query/Grammars/SQLiteGrammar.php
+++ b/Query/Grammars/SQLiteGrammar.php
@@ -173,7 +173,7 @@ class SQLiteGrammar extends Grammar
 
         return collect($values)->reject(function ($value, $key) {
             return $this->isJsonSelector($key);
-        })->merge($jsonGroups)->map(function ($value, $key) use ($jsonGroups) {
+        })->union($jsonGroups)->map(function ($value, $key) use ($jsonGroups) {
             $column = last(explode('.', $key));
 
             $value = isset($jsonGroups[$key]) ? $this->compileJsonPatch($column, $value) : $this->parameter($value);


### PR DESCRIPTION
We cant update a Column if the Column name is an Integer
example
```
DB::update([9 => "Joe" ]);
```
While became:
```
update table set "0" = 'Joe'
```
Instead of 
```
update table set "9" = 'Joe'
```