### PR TITLE
Model::setKeysForSaveQuery(Illuminate\Database\Eloquent\Builder $query) should be compatible with Illuminate\Database\Eloquent\Model::setKeysForSaveQuery($query)

### DIFF
--- a/Eloquent/Model.php
+++ b/Eloquent/Model.php
@@ -949,7 +949,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSelectQuery($query)
+    protected function setKeysForSelectQuery(Builder $query)
     {
         $query->where($this->getKeyName(), '=', $this->getKeyForSelectQuery());
 

--- a/Eloquent/Relations/Concerns/AsPivot.php
+++ b/Eloquent/Relations/Concerns/AsPivot.php
@@ -109,7 +109,7 @@ trait AsPivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery($query)
+    protected function setKeysForSaveQuery(Builder $query)
     {
         return $this->setKeysForSelectQuery($query);
     }

--- a/Eloquent/Relations/MorphPivot.php
+++ b/Eloquent/Relations/MorphPivot.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class MorphPivot extends Pivot
@@ -30,7 +31,7 @@ class MorphPivot extends Pivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery($query)
+    protected function setKeysForSaveQuery(Builder $query)
     {
         $query->where($this->morphType, $this->morphClass);
 


### PR DESCRIPTION
The method definition of `setKeysForSaveQuery` needed $query to be of type Illuminate\Database\Eloquent\Builder in the files below:

1. Eloquent/Model.php
2. Eloquent/Relations/MorphPivot.php
3. Eloquent/Relations/Concerns/AsPivot.php