### PR TITLE
Allow transaction retries when savepoints disabled

### DIFF
--- a/Concerns/ManagesTransactions.php
+++ b/Concerns/ManagesTransactions.php
@@ -78,6 +78,7 @@ trait ManagesTransactions
         // retry the query. We have to throw this exception all the way out and
         // let the developer handle it in another way. We will decrement too.
         if ($this->causedByConcurrencyError($e) &&
+            $this->queryGrammar->supportsSavepoints() &&
             $this->transactions > 1) {
             $this->transactions--;
 


### PR DESCRIPTION
In my use case, I disabled MySQL savepoints to allow DB::transaction() to retry in deadlock scenarios. However, the current logic throws the exception even though it's seemingly not necessary when savepoints are disabled. Since there is only one transaction open in MySQL, the entire transaction can be rolled back and replayed. So we check to see if the query grammar supports savepoints before throwing.