### PR TITLE
Remove duplicate updated_at column setting when soft deleting

### DIFF
--- a/Eloquent/SoftDeletes.php
+++ b/Eloquent/SoftDeletes.php
@@ -89,8 +89,6 @@ trait SoftDeletes
 
         if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
             $this->{$this->getUpdatedAtColumn()} = $time;
-
-            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
         }
 
         $query->update($columns);


### PR DESCRIPTION
There is no need to set the `$columns[$this->getUpdatedAtColumn()]` value when soft deleting, as `Illuminate\Eloquent\Query\Builder::update` already merges in the Updated At column.