### PR TITLE
Fix case insensitive relation binding.

### DIFF
--- a/Eloquent/Builder.php
+++ b/Eloquent/Builder.php
@@ -637,7 +637,14 @@ class Builder implements BuilderContract
         // and error prone. We don't want constraints because we add eager ones.
         $relation = Relation::noConstraints(function () use ($name) {
             try {
-                return $this->getModel()->newInstance()->$name();
+                $instance = $this->getModel()->newInstance();
+                $modelMethods = get_class_methods($instance);
+                $caseSensitiveMethodExists =
+                    false !== array_search($name, $modelMethods, true);
+                if (false === $caseSensitiveMethodExists) {
+                    throw new BadMethodCallException();
+                }
+                return $instance->$name();
             } catch (BadMethodCallException $e) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }


### PR DESCRIPTION
Given:
ModelA;
ModelB: belongsTo -> modelA();

When:
During eager loading, with wrong case relation.
ModelB::with('modela')->all();
This still will work but, the correct relation name should match method name "modelA"

Then:
We get 1 eager call to the database with all related IDs, then again each ID in particular to get its relation.

Proposal:
Validate relation method name before invoking it.