### PR TITLE
[8.x] Docblock updates - DB Table Creation

### DIFF
--- a/Schema/ColumnDefinition.php
+++ b/Schema/ColumnDefinition.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Fluent;
  * @method $this comment(string $comment) Add a comment to the column (MySQL/PostgreSQL)
  * @method $this default(mixed $value) Specify a "default" value for the column
  * @method $this first() Place the column "first" in the table (MySQL)
+ * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL).
  * @method $this generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(string $indexName = null) Add an index
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column


### PR DESCRIPTION
The `from()` function is missing from the doc-blocks

https://laravel.com/docs/8.x/migrations#column-modifiers