### PR TITLE
Allow queries to be lazy loaded by ID in descending order

### DIFF
--- a/Concerns/BuildsQueries.php
+++ b/Concerns/BuildsQueries.php
@@ -213,11 +213,12 @@ trait BuildsQueries
      * @param  int  $count
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  bool  $descending
      * @return \Illuminate\Support\LazyCollection
      *
      * @throws \InvalidArgumentException
      */
-    public function lazyById($chunkSize = 1000, $column = null, $alias = null)
+    public function lazyById($chunkSize = 1000, $column = null, $alias = null, $descending = false)
     {
         if ($chunkSize < 1) {
             throw new InvalidArgumentException('The chunk size should be at least 1');
@@ -233,7 +234,11 @@ trait BuildsQueries
             while (true) {
                 $clone = clone $this;
 
-                $results = $clone->forPageAfterId($chunkSize, $lastId, $column)->get();
+                if ($descending) {
+                    $results = $clone->forPageBeforeId($chunkSize, $lastId, $column)->get();
+                } else {
+                    $results = $clone->forPageAfterId($chunkSize, $lastId, $column)->get();
+                }
 
                 foreach ($results as $result) {
                     yield $result;
@@ -246,6 +251,21 @@ trait BuildsQueries
                 $lastId = $results->last()->{$alias};
             }
         });
+    }
+
+    /**
+     * Query lazily, by chunking the results of a query by comparing IDs descending.
+     *
+     * @param  int  $count
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return \Illuminate\Support\LazyCollection
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function lazyByIdDesc($chunkSize = 1000, $column = null, $alias = null)
+    {
+        return $this->lazyById($chunkSize, $column, $alias, true);
     }
 
     /**


### PR DESCRIPTION
Sometimes, when dealing with a lot of data, you need to lazily loop through models.
However, often, one would care more about the "newer" objects being processed first.
```
$query->lazyByIdDesc()
```