### PR TITLE
Add db:schema and modal:schema commands to list the column types and names

### DIFF
--- a/Console/DbSchemaCommand.php
+++ b/Console/DbSchemaCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DbSchemaCommand extends Command
+{
+    protected $signature = 'db:schema {table_name : The table whose column names and type should be listed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get all the column names and types for a table';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $tableName = $this->argument('table_name');
+
+        $this->info('Column names and types for the table: ' . $tableName);
+
+        $schemaBuilder = DB::getSchemaBuilder();
+        $data = [];
+
+        foreach ($schemaBuilder->getColumnListing($tableName) as $columnName) {
+            $data[] = [
+                'name' => $columnName,
+                'type' => $schemaBuilder->getColumnType($tableName, $columnName),
+            ];
+        }
+
+        $headers = ['Column Name', 'Type'];
+        $this->table($headers, $data);
+    }
+}

--- a/Console/Schema/DbSchemaCommand.php
+++ b/Console/Schema/DbSchemaCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Console;
+namespace Illuminate\Database\Console\Schema;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;

--- a/Console/Schema/ModelSchemaCommand.php
+++ b/Console/Schema/ModelSchemaCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Database\Console\Schema;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+
+class ModelSchemaCommand extends Command
+{
+    protected $signature = 'model:schema {model_class_name : The Model class name whose column names and type should be listed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get all the column names and types for a model';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $modelClassName = $this->argument('model_class_name');
+
+        if (!Str::startsWith($modelClassName, '\\')) {
+            $modelClassName = '\\' . $modelClassName;
+        }
+
+        $tableName = with(new $modelClassName)->getTable();
+
+        return Artisan::call('db:schema', ['table_name' => $tableName], $this->getOutput());
+    }
+}


### PR DESCRIPTION
I've seen this [Laravel Daily Tip](https://twitter.com/PovilasKorop/status/1511599089758130181). A Model/table list of column names and types is data I often look for and struggle to get after a series of migrations.

 Those commands can therefore help the Developer Experience by provinding an actionable response to this difficulty.
 
` artisan db:schema users`

<img width="541" alt="image" src="https://user-images.githubusercontent.com/3739767/162017411-0157f33d-bd53-4053-9eaf-ed3567c48f58.png">

`artisan model:schema "App\Models\User"` is accessing the table name for this model and calling the previous command

 
 