### PR TITLE
Fix README incorrect use statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $capsule->addConnection([
 ]);
 
 // Set the event dispatcher used by Eloquent models... (optional)
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Container\Container;
 $capsule->setEventDispatcher(new Dispatcher(new Container));
 


### PR DESCRIPTION
Fix incorrect using in bootstrap documentation:  Illuminate\Events\Dispatcher > Illuminate\Contracts\Events\Dispatcher

![error](https://user-images.githubusercontent.com/1455401/172068591-2dfb6aab-9188-4a09-b89d-01701bf8a91d.png)

