### PR TITLE
remove static name and AsCommand from db:wipe

### DIFF
--- a/Console/WipeCommand.php
+++ b/Console/WipeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'db:wipe')]
 class WipeCommand extends Command
 {
     use ConfirmableTrait;
@@ -18,17 +16,6 @@ class WipeCommand extends Command
      * @var string
      */
     protected $name = 'db:wipe';
-
-    /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'db:wipe';
 
     /**
      * The console command description.


### PR DESCRIPTION
Removed static name and AsCommand from db:wipe so that it is able to be hidden in laravel 0 applications.