### PR TITLE
Add ddFinalQuery() function

### DIFF
--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -622,7 +622,6 @@ class Builder implements BuilderContract
 
     /**
      * Add a "cross join" clause to the query.
-     *
      * @param  string  $table
      * @param  \Closure|string|null  $first
      * @param  string|null  $operator
@@ -3764,6 +3763,16 @@ class Builder implements BuilderContract
     public function dd()
     {
         dd($this->toSql(), $this->getBindings());
+    }
+    
+    /**
+     * Die and dump the final SQL query.
+     *
+     * @return never
+     */
+    public function ddFinalQuery()
+    {
+        dd(vsprintf(str_replace(array('?'), array('\'%s\''), $this->toSql()), $this->getBindings()));
     }
 
     /**


### PR DESCRIPTION
This function replace bind bindings in to query and die and dump final query.
when you debugging complicated queries, you need to get final query without complexity.

if you do like bellow :
```php
User::where('name','farshid')->dd(); 
```
For example you will get bellow result:
```
"SELECT * FROM users WHERE name=?;",
[
  0 => "farshid"
]
```

But if you calling
```php
User::where('name','farshid')->ddFinalQuery(); 
```
You will get bellow result:
```
"SELECT * FROM users WHERE name='farshid';"
```