### PR TITLE
Add creation and update datetime columns

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -1202,7 +1202,20 @@ class Blueprint
 
         $this->timestampTz('updated_at', $precision)->nullable();
     }
+    
+    /**
+     * Add creation and update datetime columns to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function datetimes($precision = 0)
+    {
+        $this->datetime('created_at', $precision)->nullable();
 
+        $this->datetime('updated_at', $precision)->nullable();
+    }
+    
     /**
      * Add a "deleted at" timestamp for the table.
      *


### PR DESCRIPTION
Add datetimes function to create "created_at" and "updated_at" columns using "datetime" columns instead off "timestamps" columns to add further future proofing.