### PR TITLE
Fix typo in `Blueprint` `datetime` => `dateTime`

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -1320,7 +1320,7 @@ class Blueprint
      */
     public function softDeletesDatetime($column = 'deleted_at', $precision = null)
     {
-        return $this->datetime($column, $precision)->nullable();
+        return $this->dateTime($column, $precision)->nullable();
     }
 
     /**


### PR DESCRIPTION
It still works, because of php case sensitive rules, but it's better correct