### PR TITLE
12.x add new nullableTimestampsTz method

### DIFF
--- a/Schema/Blueprint.php
+++ b/Schema/Blueprint.php
@@ -1265,6 +1265,20 @@ class Blueprint
         return $this->timestamps($precision);
     }
 
+
+    /**
+     * Add nullable creation and update timestamps to the table.
+     *
+     * Alias for self::timestampsTz().
+     *
+     * @param  int|null  $precision
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Schema\ColumnDefinition>
+     */
+    public function nullableTimestampsTz($precision = null)
+    {
+        return $this->timestampsTz($precision);
+    }
+
     /**
      * Add creation and update timestampTz columns to the table.
      *


### PR DESCRIPTION
This pull request introduces a new helper method to the `Schema\Blueprint` class to improve schema definition flexibility. The main change is the addition of the `nullableTimestampsTz` method, which serves as an alias for adding nullable timezone-aware timestamp columns.

Schema builder enhancements:

* Added the `nullableTimestampsTz` method to `Schema\Blueprint`, providing an alias for `timestampsTz()` to add nullable creation and update timestamps with timezone support.